### PR TITLE
remote controller for nodejs

### DIFF
--- a/nodejs-controller/.gitignore
+++ b/nodejs-controller/.gitignore
@@ -1,0 +1,2 @@
+!lib/
+node_modules/

--- a/nodejs-controller/index.js
+++ b/nodejs-controller/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/Controller');

--- a/nodejs-controller/lib/Controller.js
+++ b/nodejs-controller/lib/Controller.js
@@ -1,0 +1,69 @@
+var thrift = require('thrift');
+var RemoteController = require('./RemoteController');
+
+function HzRemoteController(host, port) {
+
+    var transport = thrift.TBufferedTransport();
+    var protocol =  thrift.TBinaryProtocol();
+
+    var connection = thrift.createConnection('localhost', 9701, {
+        transport: transport,
+        protocol: protocol
+    });
+
+    connection.on('error', function(err) {
+        console.log(err);
+    });
+
+    this.client = thrift.createClient(RemoteController, connection);
+}
+
+HzRemoteController.prototype.ping = function(callback) {
+    return this.client.ping(callback);
+};
+
+HzRemoteController.prototype.clean = function(callback) {
+    return this.client.clean(callback);
+};
+
+HzRemoteController.prototype.exit = function(callback) {
+    return this.client.exit(callback);
+};
+
+HzRemoteController.prototype.createCluster = function(hzVersion, xmlConfig, callback) {
+    return this.client.createCluster(hzVersion, xmlConfig, callback);
+};
+
+HzRemoteController.prototype.startMember = function(clusterId, callback) {
+    return this.client.startMember(clusterId, callback);
+};
+
+HzRemoteController.prototype.shutdownMember = function(clusterId, memberId, callback) {
+    return this.client.shutdownMember(clusterId, memberId, callback);
+};
+
+HzRemoteController.prototype.terminateMember = function(clusterId, memberId, callback) {
+    return this.client.terminateMember(clusterId, memberId, callback);
+};
+
+HzRemoteController.prototype.shutdownCluster = function(clusterId, callback) {
+    return this.client.shutdownCluster(clusterId, callback);
+};
+
+HzRemoteController.prototype.terminateCluster = function(clusterId, callback) {
+    return this.client.terminateCluster(clusterId, callback);
+};
+
+HzRemoteController.prototype.splitMemberFromCluster = function(memberId, callback) {
+    return this.client.splitMemberFromCluster(memberId, callback);
+};
+
+HzRemoteController.prototype.mergeMemberToCluster = function(clusterId, memberId, callback) {
+    return this.client.mergeMemberToCluster(clusterId, memberId, callback);
+};
+
+HzRemoteController.prototype.executeOnController = function(clusterId, script, lang, callback) {
+    return this.client.executeOnController(clusterId, script, lang, callback);
+};
+
+module.exports = HzRemoteController;

--- a/nodejs-controller/package.json
+++ b/nodejs-controller/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "hazelcast-remote-controller",
+  "version": "0.0.1",
+  "description": "Hazelcast Remote Controller",
+  "main": "index.js",
+  "scripts": {
+    "test": "mocha"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/hazelcast/hazelcast-remote-controller.git"
+  },
+  "keywords": [
+    "hazelcast",
+    "remote",
+    "controller"
+  ],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/hazelcast/hazelcast-remote-controller/issues"
+  },
+  "homepage": "https://github.com/hazelcast/hazelcast-remote-controller#readme",
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "mocha": "^2.4.5"
+  },
+  "dependencies": {
+    "thrift": "^0.9.3"
+  }
+}

--- a/nodejs-controller/test/RemoteControllerTest.js
+++ b/nodejs-controller/test/RemoteControllerTest.js
@@ -1,0 +1,72 @@
+var HzRemoteController = require('../lib/Controller');
+var expect = require('chai').expect;
+describe('Remote Controller Test', function() {
+
+    var controller;
+
+    before(function() {
+        controller = new HzRemoteController('localhost', 9701);
+    });
+
+    after(function(done) {
+        controller.exit(function(err, result) {
+            if (err == null) done();
+        })
+    });
+
+    it('ping', function(done) {
+        controller.ping(function(err, result) {
+            expect(result).to.be.true;
+            done(err);
+        })
+    });
+
+    it('create cluster', function(done) {
+        controller.createCluster(null, null, function(err, result) {
+            expect(result).to.have.property('id');
+            expect(result.id).to.not.be.null;
+            done(err);
+        });
+    });
+
+    it('start shutdown member', function(done) {
+        this.timeout(10000);
+        controller.createCluster(null, null, function(err, cluster) {
+            controller.startMember(cluster.id, function(err, member) {
+                expect(member).to.not.be.null;
+                expect(member.uuid).to.not.be.null;
+                expect(member.host).to.not.be.null;
+                expect(member.port).to.not.be.null;
+                controller.shutdownMember(cluster.id, member.uuid, function(err, result) {
+                    expect(result).to.be.true;
+                    done(err);
+                })
+            })
+        })
+    });
+
+    it('terminate member', function(done) {
+        this.timeout(10000);
+        controller.createCluster(null, null, function(err, cluster) {
+            controller.startMember(cluster.id, function(err, member) {
+                controller.terminateMember(cluster.id, member.uuid, function(err, result) {
+                    expect(result).to.be.true;
+                    done(err);
+                })
+            })
+        })
+    });
+
+    it('script executor', function(done) {
+        var script = 'function echo() { return instance_0.getSerializationService().toBytes(1.0) }; result=echo();';
+        controller.createCluster(null, null, function(err, cluster) {
+            controller.startMember(cluster.id, function(err, member) {
+                controller.executeOnController(cluster.id, script, 1, function(err, result) {
+                    expect(result.success).to.be.true;
+                    expect(result.result).to.be.an.instanceof(Object);
+                    done(err);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Hazelcast remote controller package for Node.js
It is ready for publishing and using from node.js client project.
One can use it locally without publishing the module by

1. `cd` into nodejs-controller folder
2. `npm install`
3. `npm link`
4. `cd` into other project you want to use hazelcast-controller
5. `npm link hazelcast-remote-controller`