### PR TITLE
Thrift file name change so that generated c++ files compile properly

### DIFF
--- a/thrift-bindings/generate.sh
+++ b/thrift-bindings/generate.sh
@@ -2,14 +2,14 @@
 
 GEN_LANG="$1"
 
-THRIFT_FILE="remote-controller.thrift"
+THRIFT_FILE="remote_controller.thrift"
 
 JAVA_PATH="../src/main/java"
 PYTHON_PATH="./python"
 NODEJS_PATH="./nodejs"
 CSHARP_PATH="./netstd"
 GOLANG_PATH="./golang"
-CPP_PATH="../cpp"
+CPP_PATH="../cpp-controller"
 
 echo $"Generating Thrift bindings for ${GEN_LANG}"
 
@@ -30,7 +30,7 @@ case ${GEN_LANG} in
         thrift -r --gen go -out ${GOLANG_PATH} ${THRIFT_FILE}
         ;;
     cpp)
-        thrift -r --gen cpp -out ${CPP_PATH} ${THRIFT_FILE}
+        thrift -r --gen cpp -out ${CPP_PATH}  ${THRIFT_FILE}
         ;;
     *)
         echo $"$1 not supported"

--- a/thrift-bindings/remote_controller.thrift
+++ b/thrift-bindings/remote_controller.thrift
@@ -1,6 +1,7 @@
 namespace java com.hazelcast.remotecontroller
 namespace py hzrc
 namespace netstd Hazelcast.Remote
+namespace cpp hazelcast.client.test.remote
 
 
 struct Cluster{


### PR DESCRIPTION
If the name "_remote-controller_" is used at thrift file name, then the generated c++ stubs contains header macros which would not compile. (Causes an error like "remote" is a defined macro which causes compilation error.)

Changing the name to remote_controller.thrift fixes the problem.