### PR TITLE
Remove cluster from map on shutdown

### DIFF
--- a/src/main/java/com/hazelcast/remotecontroller/ClusterManager.java
+++ b/src/main/java/com/hazelcast/remotecontroller/ClusterManager.java
@@ -142,6 +142,7 @@ public class ClusterManager {
             LOG.info("Exception during cluster shutdown: ", e);
             return false;
         }
+        this.clusterMap.remove(hzCluster.getId());
         return true;
     }
 


### PR DESCRIPTION
`ClusterManager#terminateCluster` was removing the cluster from the `clusterMap`, but `#shutdownCluster` method did not. This PR fixes that.