### PR TITLE
[API-1031] Add login modules for client security tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,17 @@
             <name>Maven2 Snapshot Repository</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
+        <repository>
+            <id>private-repository</id>
+            <name>Hazelcast Private Repository</name>
+            <url>https://repository.hazelcast.com/release/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
     </repositories>
     <properties>
         <main.basedir>${project.basedir}</main.basedir>
@@ -167,6 +178,12 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
+            <version>${hazelcast.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-enterprise</artifactId>
             <version>${hazelcast.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/src/main/java/com/hazelcast/security/SimpleCredentials.java
+++ b/src/main/java/com/hazelcast/security/SimpleCredentials.java
@@ -1,0 +1,48 @@
+package com.hazelcast.security;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+
+public class SimpleCredentials implements Credentials, IdentifiedDataSerializable {
+    static final int CLASS_ID = 1;
+
+    private String username;
+    private String password;
+
+    public SimpleCredentials() {
+    }
+
+    @Override
+    public String getName() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return SimpleCredentialsFactory.FACTORY_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return CLASS_ID;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput objectDataOutput) throws IOException {
+        objectDataOutput.writeUTF(username);
+        objectDataOutput.writeUTF(password);
+    }
+
+    @Override
+    public void readData(ObjectDataInput objectDataInput) throws IOException {
+        username = objectDataInput.readUTF();
+        password = objectDataInput.readUTF();
+    }
+}

--- a/src/main/java/com/hazelcast/security/SimpleCredentialsFactory.java
+++ b/src/main/java/com/hazelcast/security/SimpleCredentialsFactory.java
@@ -1,0 +1,16 @@
+package com.hazelcast.security;
+
+import com.hazelcast.nio.serialization.DataSerializableFactory;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+public class SimpleCredentialsFactory implements DataSerializableFactory {
+    static final int FACTORY_ID = 1;
+
+    @Override
+    public IdentifiedDataSerializable create(int classId) {
+        if (classId == SimpleCredentials.CLASS_ID) {
+            return new SimpleCredentials();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/hazelcast/security/SimpleLoginModule.java
+++ b/src/main/java/com/hazelcast/security/SimpleLoginModule.java
@@ -1,0 +1,81 @@
+package com.hazelcast.security;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+public class SimpleLoginModule implements LoginModule {
+    private static final String USERNAME_OPTION = "username";
+    private static final String PASSWORD_OPTION = "password";
+
+    private CallbackHandler callbackHandler;
+    private String username;
+    private String password;
+
+    @Override
+    public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
+        this.callbackHandler = callbackHandler;
+        this.username = (String) options.get(USERNAME_OPTION);
+        this.password = (String) options.get(PASSWORD_OPTION);
+    }
+
+    @Override
+    public boolean login() throws LoginException {
+        CredentialsCallback credentialsCb = new CredentialsCallback();
+        TokenDeserializerCallback tokenDeserializerCb = new TokenDeserializerCallback();
+        try {
+            callbackHandler.handle(new Callback[] { credentialsCb, tokenDeserializerCb });
+        } catch (IOException | UnsupportedCallbackException e) {
+            throw new LoginException("Unable to retrieve necessary data");
+        }
+
+        Credentials credentials = credentialsCb.getCredentials();
+        if (credentials == null) {
+            throw new LoginException("Credentials could not be retrieved!");
+        }
+
+        if (credentials instanceof TokenCredentials) {
+            TokenCredentials tokenCredentials = (TokenCredentials) credentials;
+            credentials = (Credentials) tokenDeserializerCb.getTokenDeserializer().deserialize(tokenCredentials);
+        }
+
+        if (credentials instanceof SimpleCredentials) {
+            SimpleCredentials simpleCredentials = (SimpleCredentials) credentials;
+            doAuthenticate(simpleCredentials);
+        } else {
+            throw new LoginException("Credentials is not an instance of SimpleCredentials!");
+        }
+
+        return true;
+    }
+
+    private void doAuthenticate(SimpleCredentials credentials) throws LoginException {
+        String username = credentials.getName();
+        String password = credentials.getPassword();
+
+        if (!Objects.equals(username, this.username) || !Objects.equals(password, this.password)) {
+            throw new LoginException("Received invalid credentials!");
+        }
+    }
+
+    @Override
+    public boolean commit() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean abort() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean logout() throws LoginException {
+        return true;
+    }
+}

--- a/src/main/java/com/hazelcast/security/TokenCredentialsLoginModule.java
+++ b/src/main/java/com/hazelcast/security/TokenCredentialsLoginModule.java
@@ -1,0 +1,85 @@
+package com.hazelcast.security;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Map;
+
+public class TokenCredentialsLoginModule implements LoginModule {
+    private static final String TOKEN_OPTION = "token";
+    private static final String ENCODING_OPTION = "encoding";
+    private static final String ASCII_ENCODING = "ascii";
+    private static final String BASE64_ENCODING = "base64";
+
+    private CallbackHandler callbackHandler;
+    private byte[] token;
+
+    @Override
+    public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
+        this.callbackHandler = callbackHandler;
+        String tokenString = (String) options.get(TOKEN_OPTION);
+        String encoding = (String) options.get(ENCODING_OPTION);
+
+        if (ASCII_ENCODING.equalsIgnoreCase(encoding) || encoding == null) {
+            this.token = tokenString.getBytes(StandardCharsets.US_ASCII);
+        } else if (BASE64_ENCODING.equalsIgnoreCase(encoding)) {
+            this.token = Base64.getDecoder().decode(tokenString);
+        } else {
+            throw new IllegalStateException("Received unknown encoding");
+        }
+    }
+
+    @Override
+    public boolean login() throws LoginException {
+        CredentialsCallback credentialsCb = new CredentialsCallback();
+        try {
+            callbackHandler.handle(new Callback[] { credentialsCb });
+        } catch (IOException | UnsupportedCallbackException e) {
+            throw new LoginException("Unable to retrieve necessary data");
+        }
+
+        Credentials credentials = credentialsCb.getCredentials();
+        if (credentials == null) {
+            throw new LoginException("Credentials could not be retrieved!");
+        }
+
+        if (credentials instanceof TokenCredentials) {
+            TokenCredentials tokenCredentials = (TokenCredentials) credentials;
+            doAuthenticate(tokenCredentials);
+        } else {
+            throw new LoginException("Credentials is not an instance of TokenCredentials!");
+        }
+
+        return true;
+    }
+
+    private void doAuthenticate(TokenCredentials credentials) throws LoginException {
+        byte[] token = credentials.getToken();
+
+        if (!Arrays.equals(token, this.token)) {
+            throw new LoginException("Received invalid credentials!");
+        }
+    }
+
+    @Override
+    public boolean commit() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean abort() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean logout() throws LoginException {
+        return true;
+    }
+}


### PR DESCRIPTION
It is not possible to test some of the authentication mechanisms
without writing Java code.

Instead of adding these modules to enterprise-tests JAR, I have
decided to add them here, so that we could use those classes
in all clients&against all v4 and v5 Hazelcast versions.

This PR introduces two separate login modules.

- One that uses custom credentials (called SimpleCredentials), and
its serialization factory.
- One that uses TokenCredentials.

There was no need to introduce a login module to test
UsernamePasswordCredentials as with the default authentication, we
can test the username and password sent by the client.