### PR TITLE
Add classes to be used with compact serialization tests

### DIFF
--- a/src/main/java/com/hazelcast/serialization/compact/CompactFilter.java
+++ b/src/main/java/com/hazelcast/serialization/compact/CompactFilter.java
@@ -1,0 +1,10 @@
+package com.hazelcast.serialization.compact;
+
+import com.hazelcast.core.IFunction;
+
+public class CompactFilter implements IFunction<Object, Boolean> {
+    @Override
+    public Boolean apply(Object o) {
+        return Boolean.TRUE;
+    }
+}

--- a/src/main/java/com/hazelcast/serialization/compact/CompactIncrementFunction.java
+++ b/src/main/java/com/hazelcast/serialization/compact/CompactIncrementFunction.java
@@ -1,0 +1,10 @@
+package com.hazelcast.serialization.compact;
+
+import com.hazelcast.core.IFunction;
+
+public class CompactIncrementFunction implements IFunction<Long, Long> {
+    @Override
+    public Long apply(Long aLong) {
+        return aLong + 1;
+    }
+}

--- a/src/main/java/com/hazelcast/serialization/compact/CompactPredicate.java
+++ b/src/main/java/com/hazelcast/serialization/compact/CompactPredicate.java
@@ -1,0 +1,12 @@
+package com.hazelcast.serialization.compact;
+
+import com.hazelcast.query.Predicate;
+
+import java.util.Map;
+
+public class CompactPredicate implements Predicate<Object, Object> {
+    @Override
+    public boolean apply(Map.Entry<Object, Object> entry) {
+        return true;
+    }
+}

--- a/src/main/java/com/hazelcast/serialization/compact/CompactReturningAggregator.java
+++ b/src/main/java/com/hazelcast/serialization/compact/CompactReturningAggregator.java
@@ -1,0 +1,20 @@
+package com.hazelcast.serialization.compact;
+
+import com.hazelcast.aggregation.Aggregator;
+
+public class CompactReturningAggregator implements Aggregator<Object, OuterCompact> {
+    @Override
+    public void accumulate(Object o) {
+
+    }
+
+    @Override
+    public void combine(Aggregator aggregator) {
+
+    }
+
+    @Override
+    public OuterCompact aggregate() {
+        return OuterCompact.INSTANCE;
+    }
+}

--- a/src/main/java/com/hazelcast/serialization/compact/CompactReturningCallable.java
+++ b/src/main/java/com/hazelcast/serialization/compact/CompactReturningCallable.java
@@ -1,0 +1,10 @@
+package com.hazelcast.serialization.compact;
+
+import java.util.concurrent.Callable;
+
+public class CompactReturningCallable implements Callable<OuterCompact> {
+    @Override
+    public OuterCompact call() throws Exception {
+        return OuterCompact.INSTANCE;
+    }
+}

--- a/src/main/java/com/hazelcast/serialization/compact/CompactReturningEntryProcessor.java
+++ b/src/main/java/com/hazelcast/serialization/compact/CompactReturningEntryProcessor.java
@@ -1,0 +1,12 @@
+package com.hazelcast.serialization.compact;
+
+import com.hazelcast.map.EntryProcessor;
+
+import java.util.Map;
+
+public class CompactReturningEntryProcessor implements EntryProcessor<Object, Object, Object> {
+    @Override
+    public Object process(Map.Entry entry) {
+        return OuterCompact.INSTANCE;
+    }
+}

--- a/src/main/java/com/hazelcast/serialization/compact/CompactReturningFunction.java
+++ b/src/main/java/com/hazelcast/serialization/compact/CompactReturningFunction.java
@@ -1,0 +1,10 @@
+package com.hazelcast.serialization.compact;
+
+import com.hazelcast.core.IFunction;
+
+public class CompactReturningFunction implements IFunction<Object, OuterCompact> {
+    @Override
+    public OuterCompact apply(Object o) {
+        return OuterCompact.INSTANCE;
+    }
+}

--- a/src/main/java/com/hazelcast/serialization/compact/CompactReturningMapInterceptor.java
+++ b/src/main/java/com/hazelcast/serialization/compact/CompactReturningMapInterceptor.java
@@ -1,0 +1,35 @@
+package com.hazelcast.serialization.compact;
+
+import com.hazelcast.map.MapInterceptor;
+
+public class CompactReturningMapInterceptor implements MapInterceptor {
+    @Override
+    public Object interceptGet(Object o) {
+        return OuterCompact.INSTANCE;
+    }
+
+    @Override
+    public void afterGet(Object o) {
+
+    }
+
+    @Override
+    public Object interceptPut(Object o, Object o1) {
+        return null;
+    }
+
+    @Override
+    public void afterPut(Object o) {
+
+    }
+
+    @Override
+    public Object interceptRemove(Object o) {
+        return null;
+    }
+
+    @Override
+    public void afterRemove(Object o) {
+
+    }
+}

--- a/src/main/java/com/hazelcast/serialization/compact/CompactReturningProjection.java
+++ b/src/main/java/com/hazelcast/serialization/compact/CompactReturningProjection.java
@@ -1,0 +1,10 @@
+package com.hazelcast.serialization.compact;
+
+import com.hazelcast.projection.Projection;
+
+public class CompactReturningProjection implements Projection<Object, Object> {
+    @Override
+    public Object transform(Object o) {
+        return OuterCompact.INSTANCE;
+    }
+}

--- a/src/main/java/com/hazelcast/serialization/compact/InnerCompact.java
+++ b/src/main/java/com/hazelcast/serialization/compact/InnerCompact.java
@@ -1,0 +1,35 @@
+package com.hazelcast.serialization.compact;
+
+import java.util.Objects;
+
+public class InnerCompact {
+
+    public static final InnerCompact INSTANCE = new InnerCompact("42");
+
+    private String stringField;
+
+    public InnerCompact() {
+
+    }
+
+    private InnerCompact(String stringField) {
+        this.stringField = stringField;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        InnerCompact inner = (InnerCompact) o;
+        return Objects.equals(stringField, inner.stringField);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(stringField);
+    }
+}

--- a/src/main/java/com/hazelcast/serialization/compact/OuterCompact.java
+++ b/src/main/java/com/hazelcast/serialization/compact/OuterCompact.java
@@ -1,0 +1,37 @@
+package com.hazelcast.serialization.compact;
+
+import java.util.Objects;
+
+public class OuterCompact {
+
+    public static final OuterCompact INSTANCE = new OuterCompact(42, InnerCompact.INSTANCE);
+
+    private int intField;
+    private InnerCompact innerField;
+
+    public OuterCompact() {
+
+    }
+
+    public OuterCompact(int intField, InnerCompact innerField) {
+        this.intField = intField;
+        this.innerField = innerField;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OuterCompact outer = (OuterCompact) o;
+        return intField == outer.intField && Objects.equals(innerField, outer.innerField);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(intField, innerField);
+    }
+}


### PR DESCRIPTION
This PR adds some compact serializable classes, so that, they can
be used for non-Java client tests.

As can be seen from the PR, only the classes are added, and we
will rely on the zero-config serialization to use them.