### PR TITLE
Empty cluster_id is ignored as well.

### DIFF
--- a/src/main/java/com/hazelcast/remotecontroller/RemoteControllerHandler.java
+++ b/src/main/java/com/hazelcast/remotecontroller/RemoteControllerHandler.java
@@ -148,7 +148,7 @@ public class RemoteControllerHandler implements RemoteController.Iface {
         if (engine == null) {
             throw new IllegalArgumentException("Could not find ScriptEngine named:" + engineName);
         }
-        if (clusterId != null) {
+        if (clusterId != null && !clusterId.isEmpty()) {
             int i = 0;
             for (HazelcastInstance instance : clusterManager.getCluster(clusterId).getInstances()) {
                 engine.put("instance_" + i++, instance);

--- a/src/main/java/com/hazelcast/remotecontroller/RemoteControllerHandler.java
+++ b/src/main/java/com/hazelcast/remotecontroller/RemoteControllerHandler.java
@@ -148,6 +148,9 @@ public class RemoteControllerHandler implements RemoteController.Iface {
         if (engine == null) {
             throw new IllegalArgumentException("Could not find ScriptEngine named:" + engineName);
         }
+        
+        // Interpret `clusterId` as null if it is empty
+        // Because thrift cpp-bindings don't support null String.
         if (clusterId != null && !clusterId.isEmpty()) {
             int i = 0;
             for (HazelcastInstance instance : clusterManager.getCluster(clusterId).getInstances()) {


### PR DESCRIPTION
This change is made because of thrift cpp bindings don't support null string semantic. So empty string should be interpreted as null as well for `clusterId`.