### PR TITLE
Add Compact credentials to test custom authentication with Compact

### DIFF
--- a/src/main/java/com/hazelcast/security/CompactCredentials.java
+++ b/src/main/java/com/hazelcast/security/CompactCredentials.java
@@ -1,0 +1,30 @@
+package com.hazelcast.security;
+
+public class CompactCredentials implements Credentials {
+
+    private String username;
+    private String key1;
+    private String key2;
+
+    public CompactCredentials() {
+    }
+
+    public CompactCredentials(String username, String key1, String key2) {
+        this.username = username;
+        this.key1 = key1;
+        this.key2 = key2;
+    }
+
+    @Override
+    public String getName() {
+        return username;
+    }
+
+    public String getKey1() {
+        return key1;
+    }
+
+    public String getKey2() {
+        return key2;
+    }
+}

--- a/src/main/java/com/hazelcast/security/CompactCredentialsLoginModule.java
+++ b/src/main/java/com/hazelcast/security/CompactCredentialsLoginModule.java
@@ -1,0 +1,45 @@
+package com.hazelcast.security;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.FailedLoginException;
+import javax.security.auth.login.LoginException;
+import java.io.IOException;
+
+public class CompactCredentialsLoginModule extends ClusterLoginModule {
+    private String name;
+
+    @Override
+    protected boolean onLogin() throws LoginException {
+        CredentialsCallback cb = new CredentialsCallback();
+        TokenDeserializerCallback tdcb = new TokenDeserializerCallback();
+        try {
+            callbackHandler.handle(new Callback[]{cb, tdcb});
+        } catch (IOException | UnsupportedCallbackException e) {
+            throw new LoginException("Problem getting credentials");
+        }
+        Credentials credentials = cb.getCredentials();
+        if (credentials instanceof TokenCredentials) {
+            TokenCredentials tokenCreds = (TokenCredentials) credentials;
+            credentials = (Credentials) tdcb.getTokenDeserializer().deserialize(tokenCreds);
+        }
+        if (!(credentials instanceof CompactCredentials)) {
+            throw new FailedLoginException();
+        }
+        CompactCredentials cc = (CompactCredentials) credentials;
+        if (cc.getName().equals(options.get("username"))
+                && cc.getKey1().equals(options.get("key1"))
+                && cc.getKey2().equals(options.get("key2"))) {
+            name = cc.getName();
+            addRole(name);
+            return true;
+        }
+        throw new LoginException("Invalid credentials");
+    }
+
+    @Override
+    protected String getName() {
+        return name;
+    }
+}
+

--- a/src/main/java/com/hazelcast/security/CompactCredentialsLoginModule.java
+++ b/src/main/java/com/hazelcast/security/CompactCredentialsLoginModule.java
@@ -5,6 +5,7 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.FailedLoginException;
 import javax.security.auth.login.LoginException;
 import java.io.IOException;
+import java.util.Objects;
 
 public class CompactCredentialsLoginModule extends ClusterLoginModule {
     private String name;
@@ -16,25 +17,37 @@ public class CompactCredentialsLoginModule extends ClusterLoginModule {
         try {
             callbackHandler.handle(new Callback[]{cb, tdcb});
         } catch (IOException | UnsupportedCallbackException e) {
-            throw new LoginException("Problem getting credentials");
+            throw new LoginException("Failed to get the credentials");
         }
+
         Credentials credentials = cb.getCredentials();
         if (credentials instanceof TokenCredentials) {
-            TokenCredentials tokenCreds = (TokenCredentials) credentials;
-            credentials = (Credentials) tdcb.getTokenDeserializer().deserialize(tokenCreds);
+            TokenCredentials tokenCredentials = (TokenCredentials) credentials;
+            credentials = (Credentials) tdcb.getTokenDeserializer().deserialize(tokenCredentials);
         }
+
         if (!(credentials instanceof CompactCredentials)) {
-            throw new FailedLoginException();
+            throw new FailedLoginException("The " + credentials + " is not of type " + CompactCredentials.class.getSimpleName());
         }
+
         CompactCredentials cc = (CompactCredentials) credentials;
-        if (cc.getName().equals(options.get("username"))
-                && cc.getKey1().equals(options.get("key1"))
-                && cc.getKey2().equals(options.get("key2"))) {
-            name = cc.getName();
-            addRole(name);
-            return true;
+        String username = Objects.requireNonNull(cc.getName(), "Username of the credentials cannot be null");
+        String key1 = Objects.requireNonNull(cc.getKey1(), "Key1 of the credentials cannot be null");
+        String key2 = Objects.requireNonNull(cc.getKey2(), "Key2 of the credentials cannot be null");
+
+        String configuredUsername = Objects.requireNonNull((String) options.get("username"), "Configured username cannot be null");
+        String configuredKey1 = Objects.requireNonNull((String) options.get("key1"), "Configured key1 cannot be null");
+        String configuredKey2 = Objects.requireNonNull((String) options.get("key2"), "Configured key2 cannot be null");
+
+        if (!username.equals(configuredUsername)
+                || !key1.equals(configuredKey1)
+                || !key2.equals(configuredKey2)) {
+            throw new LoginException("Invalid credentials. Make sure the configured properties are the same with the credentials sent.");
         }
-        throw new LoginException("Invalid credentials");
+
+        name = username;
+        addRole(name);
+        return true;
     }
 
     @Override
@@ -42,4 +55,3 @@ public class CompactCredentialsLoginModule extends ClusterLoginModule {
         return name;
     }
 }
-


### PR DESCRIPTION
This PR adds a Compact serializable credentials class and associated login module, so that the custom authentication with Compact can be tested in non-java clients.

The non-Java clients would need to write a serializer for the CompactCredentials in their language, and use the fully qualified class name as the type name (`com.hazelcast.security.CompactCredentials`) so that the Java can use reflective serializer to deserialize it, just like other Compact classes put into remote-controller.

To use this login module in non-Java client tests, one has to use a configuration like below

```xml
<hazelcast xmlns="http://www.hazelcast.com/schema/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
    <security enabled="true">
        <realms>
            <realm name="realm">
                <authentication>
                    <jaas>
                        <login-module class-name="com.hazelcast.security.CompactCredentialsLoginModule" usage="REQUIRED">
                            <properties>
                                <property name="key2">xyz</property>
                                <property name="key1">abc</property>
                                <property name="username">user</property>
                            </properties>
                        </login-module>
                    </jaas>
                </authentication>
            </realm>
        </realms>
        <client-authentication realm="realm"/>
    </security>
</hazelcast>
```