### PR TITLE
RC viridian support followup PR API-1785

### DIFF
--- a/src/main/java/com/hazelcast/remotecontroller/CloudManager.java
+++ b/src/main/java/com/hazelcast/remotecontroller/CloudManager.java
@@ -386,13 +386,13 @@ public class CloudManager {
         return json.replaceAll("\"token\"\\s*:\\s*\"(.*)\"", "\"token\":\"******\"");
     }
 
-    // It creates a folder with name clusterId under /home/user/
+    // It creates a folder with name clusterId under the directory jvm invoked.
     // Then it downloads the certificates for the cluster and put them in the created folder
     private String downloadCertificatesAndGetPath(String clusterId) throws CloudException {
         try
         {
-            String userHome = System.getProperty("user.home");
-            Path pathClusterId = Paths.get(userHome, clusterId);
+            String currentDirectory = System.getProperty("user.dir");
+            Path pathClusterId = Paths.get(currentDirectory, clusterId);
 
             // If folder with clusterId is there then certificates are already downloaded
             if (!Files.exists(pathClusterId))

--- a/src/main/java/com/hazelcast/remotecontroller/CloudManager.java
+++ b/src/main/java/com/hazelcast/remotecontroller/CloudManager.java
@@ -98,7 +98,7 @@ public class CloudManager {
                     hazelcastVersion,
                     isTlsEnabled);
 
-            LOG.info(String.format("Request query: %s", jsonString));
+            // LOG.info(String.format("Request query: %s", jsonString));
             try (Response response = sendPostRequest("/cluster", jsonString)){
                 ResponseBody responseBody = response.body();
                 if (responseBody == null) {
@@ -106,7 +106,7 @@ public class CloudManager {
                 }
                 String responseString = responseBody.string();
                 throwIfResponseFailed(response, responseString);
-                LOG.info(maskValueOfToken(responseString));
+                // LOG.info(maskValueOfToken(responseString));
                 clusterId = mapper.readTree(responseString).get("id").asText();
                 waitForStateOfCluster(clusterId, "RUNNING", TimeUnit.MINUTES.toMillis(TIMEOUT_FOR_CLUSTER_STATE_WAIT_IN_MINUTES));
                 return getCloudCluster(clusterId);
@@ -142,7 +142,7 @@ public class CloudManager {
                 }
                 String responseString = responseBody.string();
                 throwIfResponseFailed(res, responseString);
-                LOG.info(maskValueOfToken(responseString));
+                // LOG.info(maskValueOfToken(responseString));
                 JsonNode rootNode = mapper.readTree(responseString);
                 if (rootNode.asText().equalsIgnoreCase("null")) {
                     throw new CloudException(String.format("Cluster with id %s is not found", clusterId));
@@ -170,7 +170,7 @@ public class CloudManager {
                 }
                 String responseString = responseBody.string();
                 throwIfResponseFailed(res, responseString);
-                LOG.info(maskValueOfToken(responseString));
+                // LOG.info(maskValueOfToken(responseString));
                 waitForStateOfCluster(clusterId, "STOPPED", TimeUnit.MINUTES.toMillis(TIMEOUT_FOR_CLUSTER_STATE_WAIT_IN_MINUTES));
                 return getCloudCluster(clusterId);
             }
@@ -188,7 +188,7 @@ public class CloudManager {
                 }
                 String responseString = responseBody.string();
                 throwIfResponseFailed(res, responseString);
-                LOG.info(maskValueOfToken(responseString));
+                // LOG.info(maskValueOfToken(responseString));
                 waitForStateOfCluster(clusterId, "RUNNING", TimeUnit.MINUTES.toMillis(TIMEOUT_FOR_CLUSTER_STATE_WAIT_IN_MINUTES));
                 return getCloudCluster(clusterId);
             }
@@ -206,7 +206,7 @@ public class CloudManager {
                 }
                 String responseString = responseBody.string();
                 throwIfResponseFailed(res, responseString);
-                LOG.info(maskValueOfToken(responseString));
+                // LOG.info(maskValueOfToken(responseString));
                 waitForDeletedCluster(clusterId, TimeUnit.MINUTES.toMillis(TIMEOUT_FOR_CLUSTER_STATE_WAIT_IN_MINUTES));
                 LOG.info(String.format("Cluster with id %s is deleted", clusterId));
             }
@@ -317,7 +317,7 @@ public class CloudManager {
                     }
                     String responseString = responseBody.string();
                     throwIfResponseFailed(response, responseString);
-                    LOG.info(maskValueOfToken(responseString));
+                    // LOG.info(maskValueOfToken(responseString));
                     currentState = mapper.readTree(responseString).get("state").asText();
                     if (currentState.equalsIgnoreCase(expectedState)) {
                         return;
@@ -373,7 +373,7 @@ public class CloudManager {
             }
             String responseString = responseBody.string();
             throwIfResponseFailed(response, responseString);
-            LOG.info(maskValueOfToken(responseString));
+            // LOG.info(maskValueOfToken(responseString));
             return mapper.readTree(responseString).get("token").asText();
         } catch (Exception e) {
             throw new CloudException("Get bearer token is failed. " + getErrorString(e));
@@ -438,7 +438,7 @@ public class CloudManager {
 
         boolean deleted = new File(pathResponseZip.toString()).delete();
         if (!deleted) {
-            LOG.warn(String.format("Could not delete file %s", pathResponseZip));
+            LOG.warn(String.format("Could not delete certificate zip file %s", pathResponseZip));
         }
     }
 }

--- a/src/main/java/com/hazelcast/remotecontroller/CloudManager.java
+++ b/src/main/java/com/hazelcast/remotecontroller/CloudManager.java
@@ -30,7 +30,7 @@ public class CloudManager {
     private static final OkHttpClient CLIENT = new OkHttpClient();
     private static final Logger LOG = LogManager.getLogger(Main.class);
     private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
-    private static final int TIMEOUT_FOR_CLUSTER_STATE_WAIT_IN_MINUTES = 5;
+    private static final int TIMEOUT_FOR_CLUSTER_STATE_WAIT_IN_MINUTES = 10;
     private static final int RETRY_TIME_IN_SECOND = 10;
     private static final int CLUSTER_TYPE_ID = 5; // Serverless cluster
     private static final int CLOUD_PROVIDER_ID = 1; // aws

--- a/src/main/java/com/hazelcast/remotecontroller/CloudManager.java
+++ b/src/main/java/com/hazelcast/remotecontroller/CloudManager.java
@@ -27,7 +27,6 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 public class CloudManager {
-    private static final OkHttpClient CLIENT = new OkHttpClient();
     private static final Logger LOG = LogManager.getLogger(Main.class);
     private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
     private static final int TIMEOUT_FOR_CLUSTER_STATE_WAIT_IN_MINUTES = 10;
@@ -37,6 +36,9 @@ public class CloudManager {
     private static final int CLOUD_PROVIDER_REGION_ID = 4; // us-west-2
     private static final String CLUSTER_PLAN = "SERVERLESS";
     private final ObjectMapper mapper = new ObjectMapper();
+    // Make these timeouts pretty long to avoid timeout errors. The dev environment is slow.
+    private static final OkHttpClient client = (new OkHttpClient.Builder())
+            .connectTimeout(2, TimeUnit.MINUTES).readTimeout(2, TimeUnit.MINUTES).build();
     private String baseUrl;
     private String bearerToken;
     private Call call;
@@ -229,7 +231,7 @@ public class CloudManager {
                 reqBuilder.post(RequestBody.create(null, new byte[0]));
             }
             Request request = reqBuilder.build();
-            call = CLIENT.newCall(request);
+            call = client.newCall(request);
             return call.execute();
         } catch (Exception e) {
             Log.warn(maskValueOfToken(e.toString()));
@@ -247,7 +249,7 @@ public class CloudManager {
                     .header("Content-Type", "application/json")
                     .get()
                     .build();
-            call = CLIENT.newCall(request);
+            call = client.newCall(request);
             return call.execute();
         } catch (Exception e) {
             Log.warn(maskValueOfToken(e.toString()));
@@ -265,7 +267,7 @@ public class CloudManager {
                     .header("Content-Type", "application/json")
                     .build();
 
-            call = CLIENT.newCall(request);
+            call = client.newCall(request);
             return call.execute();
         } catch (Exception e) {
             Log.warn(maskValueOfToken(e.toString()));
@@ -286,7 +288,7 @@ public class CloudManager {
                     .get()
                     .header("Authorization", String.format("Bearer %s", bearerToken))
                     .build();
-            call = CLIENT.newCall(request);
+            call = client.newCall(request);
             Response response = call.execute();
             try {
                 ResponseBody responseBody = response.body();
@@ -365,7 +367,7 @@ public class CloudManager {
                     .post(body)
                     .header("Content-Type", "application/json")
                     .build();
-            call = CLIENT.newCall(request);
+            call = client.newCall(request);
             Response response = call.execute();
             ResponseBody responseBody = response.body();
             if (responseBody == null) {
@@ -422,7 +424,7 @@ public class CloudManager {
                 .header("Authorization", String.format("Bearer %s", bearerToken))
                 .build();
 
-        call = CLIENT.newCall(request);
+        call = client.newCall(request);
         Response response = call.execute();
         try (FileOutputStream stream = new FileOutputStream(pathResponseZip.toString())) {
             ResponseBody responseBody = response.body();


### PR DESCRIPTION
I forgot to mask tokens in some logging statements and we were printing apiKey and apiSecret, I removed it.

Also I fixed some code that my IDE was giving warnings about.

I also changed certificate download path from user.home to user.dir because it is annoying to download certificates into home directory. 

I increased the state transition timeout as well. In my local a cluster state change can take around 5 minutes.

 I realized response strings can include cluster passwords and the token in mc login link. I think these are sensitive. Therefore, I commented out all the logging about cloud responses.

I also realized that tests fail with timeout error in java client tests, so I made socket and connect timeout 2 mins. See https://github.com/srknzl/client-compatibility-suites/actions/runs/4116717397/jobs/7107109729.