### PR TITLE
Change CloudManager logger class to CloudManager

### DIFF
--- a/src/main/java/com/hazelcast/remotecontroller/CloudManager.java
+++ b/src/main/java/com/hazelcast/remotecontroller/CloudManager.java
@@ -27,7 +27,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 public class CloudManager {
-    private static final Logger LOG = LogManager.getLogger(Main.class);
+    private static final Logger LOG = LogManager.getLogger(CloudManager.class);
     private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
     private static final int TIMEOUT_FOR_CLUSTER_STATE_WAIT_IN_MINUTES = 10;
     private static final int RETRY_TIME_IN_SECOND = 10;


### PR DESCRIPTION
This is needed because I will reuse the CloudManager class in client compat suites repo, and Main class cannot be imported may be causing problems. 

When I copy CloudManager.java to compat repo, and change the Logger class to CloudManager it passed: https://github.com/srknzl/client-compatibility-suites/actions/runs/4124846885

After this PR is merged, I will remove the copied class and reuse the class in the rc jar. 