### PR TITLE
Log cluster state to see why cloud tests last hours

### DIFF
--- a/src/main/java/com/hazelcast/remotecontroller/CloudManager.java
+++ b/src/main/java/com/hazelcast/remotecontroller/CloudManager.java
@@ -322,8 +322,10 @@ public class CloudManager {
                     throwIfResponseFailed(response, responseString);
                     // LOG.info(maskValueOfToken(responseString));
                     currentState = mapper.readTree(responseString).get("state").asText();
-                    LOG.warn("Cluster state is expected to be " + expectedState + " and it is " + currentState + "");
-                    if (currentState.equalsIgnoreCase(expectedState)) {
+                    boolean statesEqual = currentState.equalsIgnoreCase(expectedState);
+                    LOG.warn(String.format("Cluster state is expected to be %s and it is %s. Current state equals expected: %b",
+                            expectedState, currentState, statesEqual));
+                    if (statesEqual) {
                         return;
                     }
                     if (currentState.equalsIgnoreCase("FAILED")) {

--- a/src/main/java/com/hazelcast/remotecontroller/CloudManager.java
+++ b/src/main/java/com/hazelcast/remotecontroller/CloudManager.java
@@ -322,6 +322,7 @@ public class CloudManager {
                     throwIfResponseFailed(response, responseString);
                     // LOG.info(maskValueOfToken(responseString));
                     currentState = mapper.readTree(responseString).get("state").asText();
+                    LOG.warn("Cluster state is expected to be " + expectedState + " and it is " + currentState + "");
                     if (currentState.equalsIgnoreCase(expectedState)) {
                         return;
                     }


### PR DESCRIPTION
Currently, python tests are passing but in hours. I realized that it's due to the fact that RC waits for state for 10 minutes. (because it it the timeout) There is no error thrown though.  I can clearly say that the cluster switches to the correct states in short time. But the test code gets stuck in stopCloudCluster or resumeCloudCluster. There may be a bug in the RC waitForStateCluster method or the API may be returning something differently. I added some debug logging for checking the situation.