### PR TITLE
Upgrade to Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,15 +32,12 @@
         <main.basedir>${project.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <jdk.version>8</jdk.version>
+        <jdk.version>17</jdk.version>
         <target.dir>target</target.dir>
         <maven.build.timestamp.format>yyyyMMdd</maven.build.timestamp.format>
         <timestamp>${maven.build.timestamp}</timestamp>
 
-        <!-- Not using 3.1 at the moment since it recompiles all classes every time -->
-        <!-- https://jira.codehaus.org/browse/MCOMPILER-205 -->
-        <!--<maven.compiler.plugin.version>3.1</maven.compiler.plugin.version>-->
-        <maven.compiler.plugin.version>2.5.1</maven.compiler.plugin.version>
+        <maven.compiler.plugin.version>3.12.1</maven.compiler.plugin.version>
         <maven.dependency.plugin.version>2.10</maven.dependency.plugin.version>
         <log4j2.version>2.15.0</log4j2.version>
         <junit.version>4.12</junit.version>
@@ -111,14 +108,14 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven.compiler.plugin.version}</version>
                 <configuration>
-                    <source>${jdk.version}</source>
-                    <target>${jdk.version}</target>
+                    <release>${jdk.version}</release>
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -130,6 +127,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -208,6 +206,11 @@
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>3.9.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.nashorn</groupId>
+            <artifactId>nashorn-core</artifactId>
+            <version>15.4</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
`hazelcast-rest-controller` is used as part of the `client-compatibility-suites` tests, but since they have been [upgraded to use a Java 17 runtime](https://github.com/hazelcast/client-compatibility-suites/pull/84), these [are failing](https://github.com/srknzl/client-compatibility-suites/actions/runs/7815412488/job/21319268716) as `hazelcast-remote-controller` does not work on Java 17.

Changes:
- added `nashorn` dependency to support Javascript evaluation
   - [no longer bundled with JDK](https://github.com/szegedi/nashorn/wiki/Using-Nashorn-with-different-Java-versions)
- upgrade to latest `maven-compiler-plugin`
   - unsure if version from 2012 would support Java 17
- add explicit versions to `maven-jar-plugin` / `maven-shade-plugin`
   - ensures build reproducibility
   - versions mimic those used in `hazelcast`
- upgrade to a Java 17 code level
   - Requires a minimum Java 17 runtime
   - Not **required** for runtime compatibility