### PR TITLE
Add Nashorn Support after Java 17 Upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <main.basedir>${project.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <jdk.version>8</jdk.version>
+        <jdk.version>17</jdk.version>
         <target.dir>target</target.dir>
         <maven.build.timestamp.format>yyyyMMdd</maven.build.timestamp.format>
         <timestamp>${maven.build.timestamp}</timestamp>
@@ -46,7 +46,7 @@
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
 
-        <hazelcast.version>4.0</hazelcast.version>
+        <hazelcast.version>5.3.6</hazelcast.version>
         <thrift.version>0.13.0</thrift.version>
     </properties>
 
@@ -141,7 +141,6 @@
             </plugin>
         </plugins>
     </build>
-
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -209,8 +208,12 @@
             <artifactId>okhttp</artifactId>
             <version>3.9.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.openjdk.nashorn</groupId>
+            <artifactId>nashorn-core</artifactId>
+            <version>15.4</version>
+        </dependency>
     </dependencies>
-
     <distributionManagement>
         <repository>
             <id>release-repository</id>

--- a/src/main/resources/META-INF/services/javax.script.ScriptEngineFactory
+++ b/src/main/resources/META-INF/services/javax.script.ScriptEngineFactory
@@ -1,0 +1,2 @@
+org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory
+org.python.jsr223.PyScriptEngineFactory


### PR DESCRIPTION
It introduces Nashorn support for Javascript scripting. Jython was already included. It should work. Also, both Jython and Nashorn register themself with same META-INF.services info, that was causing an overlapping. Hence, services were not found by the class loader. With an explicit service meta-inf, that is solved.

I've tried few clients tests which require scripting against the PR, and they are successful. I expect same behavior on rest of the tests. 