### PR TITLE
Add Nashorn Support after Java 17 Upgrade (Correct PR)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,11 @@
         <hamcrest.version>1.3</hamcrest.version>
         <hazelcast.version>4.0</hazelcast.version>
         <thrift.version>0.13.0</thrift.version>
+        <jackson-databind.version>2.12.3</jackson-databind.version>
+        <zip4j.version>2.9.1</zip4j.version>
+        <okhttp.version>3.9.0</okhttp.version>
+        <nashorn-core.version>15.4</nashorn-core.version>
+        <jython-standalone.version>2.7.2</jython-standalone.version>
     </properties>
 
     <licenses>
@@ -195,27 +200,27 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.3</version>
+            <version>${jackson-databind.version}</version>
         </dependency>
         <dependency>
             <groupId>net.lingala.zip4j</groupId>
             <artifactId>zip4j</artifactId>
-            <version>2.9.1</version>
+            <version>${zip4j.version}</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>3.9.0</version>
+            <version>${okhttp.version}</version>
         </dependency>
         <dependency>
             <groupId>org.openjdk.nashorn</groupId>
             <artifactId>nashorn-core</artifactId>
-            <version>15.4</version>
+            <version>${nashorn-core.version}</version>
         </dependency>
         <dependency>
             <groupId>org.python</groupId>
             <artifactId>jython-standalone</artifactId>
-            <version>2.7.2</version>
+            <version>${jython-standalone.version}</version>
         </dependency>
     </dependencies>
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
 
-        <hazelcast.version>5.3.6</hazelcast.version>
+        <hazelcast.version>4.0</hazelcast.version>
         <thrift.version>0.13.0</thrift.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <description>Hazelcast Remote Controller Server Container</description>
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-remote-controller</artifactId>
-    <version>0.8-SNAPSHOT</version>
+    <version>0.9-SNAPSHOT</version>
 
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <main.basedir>${project.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <jdk.version>8</jdk.version>
+        <jdk.version>17</jdk.version>
         <target.dir>target</target.dir>
         <maven.build.timestamp.format>yyyyMMdd</maven.build.timestamp.format>
         <timestamp>${maven.build.timestamp}</timestamp>
@@ -46,7 +46,7 @@
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
 
-        <hazelcast.version>4.0</hazelcast.version>
+        <hazelcast.version>5.3.6</hazelcast.version>
         <thrift.version>0.13.0</thrift.version>
     </properties>
 
@@ -141,7 +141,6 @@
             </plugin>
         </plugins>
     </build>
-
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -209,8 +208,12 @@
             <artifactId>okhttp</artifactId>
             <version>3.9.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.openjdk.nashorn</groupId>
+            <artifactId>nashorn-core</artifactId>
+            <version>15.4</version>
+        </dependency>
     </dependencies>
-
     <distributionManagement>
         <repository>
             <id>release-repository</id>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <description>Hazelcast Remote Controller Server Container</description>
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-remote-controller</artifactId>
-    <version>0.9-SNAPSHOT</version>
+    <version>0.8-SNAPSHOT</version>
 
     <repositories>
         <repository>
@@ -40,12 +40,14 @@
         <!-- Not using 3.1 at the moment since it recompiles all classes every time -->
         <!-- https://jira.codehaus.org/browse/MCOMPILER-205 -->
         <!--<maven.compiler.plugin.version>3.1</maven.compiler.plugin.version>-->
-        <maven.compiler.plugin.version>2.5.1</maven.compiler.plugin.version>
+        <maven.compiler.plugin.version>3.12.1</maven.compiler.plugin.version>
         <maven.dependency.plugin.version>2.10</maven.dependency.plugin.version>
+        <maven.jar.plugin.version>3.3.0</maven.jar.plugin.version>
+        <maven.shade.plugin.version>3.5.1</maven.shade.plugin.version>
+
         <log4j2.version>2.15.0</log4j2.version>
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
-
         <hazelcast.version>4.0</hazelcast.version>
         <thrift.version>0.13.0</thrift.version>
     </properties>
@@ -111,14 +113,14 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven.compiler.plugin.version}</version>
                 <configuration>
-                    <source>${jdk.version}</source>
-                    <target>${jdk.version}</target>
+                    <release>${jdk.version}</release>
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven.jar.plugin.version}</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -130,6 +132,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
+                <version>${maven.shade.plugin.version}</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -169,11 +172,7 @@
             <artifactId>libthrift</artifactId>
             <version>${thrift.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.python</groupId>
-            <artifactId>jython-standalone</artifactId>
-            <version>2.7.0</version>
-        </dependency>
+
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
@@ -212,6 +211,11 @@
             <groupId>org.openjdk.nashorn</groupId>
             <artifactId>nashorn-core</artifactId>
             <version>15.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.python</groupId>
+            <artifactId>jython-standalone</artifactId>
+            <version>2.7.2</version>
         </dependency>
     </dependencies>
     <distributionManagement>

--- a/src/main/resources/META-INF/services/javax.script.ScriptEngineFactory
+++ b/src/main/resources/META-INF/services/javax.script.ScriptEngineFactory
@@ -1,0 +1,2 @@
+org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory
+org.python.jsr223.PyScriptEngineFactory


### PR DESCRIPTION
It introduces Nashorn support for Javascript scripting. Jython was already included. It should work. Also, both Jython and Nashorn register themself with same META-INF.services info, that was causing an overlapping. Hence, services were not found by the class loader. With an explicit service meta-inf, that is solved.

I've tried few clients tests which require scripting against the PR, and they are successful. I expect same behavior on rest of the tests.


**Note: This PR is correction of https://github.com/hazelcast/hazelcast-remote-controller/pull/71 Please, continue from here.**