### PR TITLE
Replace explicit JFrog token with tokenless-OIDC authentication [DI-706]

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     if: github.repository_owner == 'hazelcast'
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,12 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: hazelcast/docker-actions/get-jfrog-credentials@master
-        id: jfrog
-        with:
-          aws-role-to-assume: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
-          jfrog-oidc-provider-name: ${{ github.repository_owner }}-write-dev-account
-
       - uses: actions/setup-java@v5
         with:
           java-version: 17
@@ -30,6 +24,12 @@ jobs:
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
           cache: 'maven'
+
+      - uses: hazelcast/docker-actions/get-jfrog-credentials@master
+        id: jfrog
+        with:
+          aws-role-to-assume: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
+          jfrog-oidc-provider-name: ${{ github.repository_owner }}-write-dev-account
 
       - run: |
           mvn \

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -12,6 +12,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # Should be a relative local path, but doesn't resolve when called from another repo
+      - uses: hazelcast/docker-actions/get-jfrog-credentials@master
+        id: jfrog
+        with:
+          aws-role-to-assume: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
+          jfrog-oidc-provider-name: ${{ github.repository_owner }}-write-dev-account
+
       - uses: actions/setup-java@v5
         with:
           java-version: 17
@@ -30,6 +37,6 @@ jobs:
             --batch-mode \
             --no-transfer-progress
         env:
-          MAVEN_USERNAME: ${{ secrets.JFROG_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
+          MAVEN_USERNAME: ${{ steps.jfrog.outputs.user }}
+          MAVEN_PASSWORD: ${{ steps.jfrog.outputs.token }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -12,7 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # Should be a relative local path, but doesn't resolve when called from another repo
       - uses: hazelcast/docker-actions/get-jfrog-credentials@master
         id: jfrog
         with:


### PR DESCRIPTION
See:
- https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-jfrog
- [ADR](https://hazelcast.atlassian.net/wiki/spaces/EN/pages/6645022721/ADR-00089-+Type+2+-Migrate+GitHub+Actions+to+use+tokenless+OIDC+authentication)
- [reference `hazelcast-docker` implementation](https://github.com/hazelcast/hazelcast-docker/pull/1192)

Fixes: [DI-706](https://hazelcast.atlassian.net/browse/DI-706)

[Example execution](https://github.com/hazelcast/hazelcast-remote-controller/actions/runs/23541078818).

[DI-706]: https://hazelcast.atlassian.net/browse/DI-706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ